### PR TITLE
fix "case-insensitive import collision"

### DIFF
--- a/poloniexcli/commands/balances.go
+++ b/poloniexcli/commands/balances.go
@@ -5,7 +5,7 @@ import (
 	"text/tabwriter"
 	"text/template"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/robvanmieghem/poloniex/poloniexclient"
 )
 

--- a/poloniexcli/commands/loanorders.go
+++ b/poloniexcli/commands/loanorders.go
@@ -5,7 +5,7 @@ import (
 	"text/tabwriter"
 	"text/template"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/robvanmieghem/poloniex/poloniexclient"
 )
 

--- a/poloniexcli/commands/orderbook.go
+++ b/poloniexcli/commands/orderbook.go
@@ -6,7 +6,7 @@ import (
 	"text/tabwriter"
 	"text/template"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/robvanmieghem/poloniex/poloniexclient"
 )
 

--- a/poloniexcli/main.go
+++ b/poloniexcli/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/codegangsta/cli"
 	"github.com/robvanmieghem/poloniex/poloniexcli/commands"
 )

--- a/poloniexclient/client.go
+++ b/poloniexclient/client.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/poloniexclient/loanorders.go
+++ b/poloniexclient/loanorders.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 //LoanOrder is a single an order (offer or demand) for a specific rate

--- a/poloniexclient/orderbook.go
+++ b/poloniexclient/orderbook.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strconv"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 //OrderBookEntry is a value/amount combination representing an entry in an OrderBook


### PR DESCRIPTION
related issue
https://github.com/sirupsen/logrus/issues/543

`github.com/Sirupsen/logrus` is replaced. now, `github.com/sirupsen/logrus`
Without changing, those error raise.

```
$ go get github.com/robvanmieghem/poloniex/poloniexclient                                                                  
can't load package: package github.com/robvanmieghem/poloniex/poloniexclient: case-insensitive import collision: "github.com/Sirupsen/logrus" and "github.com/sirupsen/logrus"
```
