### PR TITLE
add content-type to call trade api

### DIFF
--- a/poloniexclient/client.go
+++ b/poloniexclient/client.go
@@ -115,6 +115,9 @@ func (poloniexClient *PoloniexClient) executeTradingAPICommand(command string, p
 
 	req.Header.Add("Sign", signature)
 
+	// with content-type, "error: invalid command" raise
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
 	logRequest(req)
 	resp, err := poloniexClient.httpClient.Do(req)
 	logResponse(resp, err)


### PR DESCRIPTION
https://github.com/thrasher-/gocryptotrader/blob/b84a27a6a57ad49c56622ec7c8b3e5da734d65e9/exchanges/poloniex/poloniex.go#L728

`Content-Type: application/x-www-form-urlencoded` is required to call trading API.
Without this, poloniex server return "invalid command" error.


